### PR TITLE
refactor(crud-request): remove redundant `stringify`

### DIFF
--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -1,11 +1,11 @@
 import {
   hasLength,
   hasValue,
-  isString,
   isArrayFull,
   isDate,
   isDateString,
   isObject,
+  isString,
   isStringFull,
   objKeys,
 } from '@nestjsx/util';
@@ -202,18 +202,18 @@ export class RequestQueryParser implements ParsedRequestParams {
       objectData = JSON.parse(data);
       // tslint:disable-next-line
     } catch (e) {}
-    if (objectData !== undefined) {
-      if (Array.isArray(objectData)) {
-        if (objectData.length === 1) {
-          return this.conditionParser(cond, JSON.stringify(objectData[0]));
-        }
 
-        return objectData.map((o) =>
-          this.conditionParser(cond, JSON.stringify(o)),
-        ) as QueryFilter;
-      } else {
-        return this.conditionParser(cond, objectData);
-      }
+    const filters: QueryFilter =
+      isArrayFull(objectData) || isStringFull(objectData)
+        ? this.parseCondition(cond, objectData)
+        : this.parseCondition(cond, data);
+
+    return Array.isArray(filters) && filters.length === 1 ? filters[0] : filters;
+  }
+
+  private parseCondition(cond: 'filter' | 'or', data: string | any[]) {
+    if (Array.isArray(data)) {
+      return data.map((o) => this.parseCondition(cond, o));
     }
 
     const isArrayValue = ['in', 'notin', 'between'];


### PR DESCRIPTION
What I want to say is actually this.

keep only one `JSON.parse` is enough to do so

too many `parse` and `stringify` in recursive maybe confusing others

Am I doing right? It passes all tests. Double check @Darkein 